### PR TITLE
Tiny fixed READEME.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Usage
 
-    $ npm install textlint textlint-rule-max-ten
+    $ npm install textlint textlint-rule-max-number-of-lines
     $ textlint --rule textlint-rule-max-number-of-lines README.md
     # Document is too long(number of lines: 679).
 
@@ -22,7 +22,7 @@ Add config to `.textlintrc`
 {
   "rules": {
     "max-number-of-lines": {
-        "max" : 300 
+        "max" : 300
     }
   }
 }


### PR DESCRIPTION
Once I copied and pasted codes there and tried to textlint on CLI, it was failed to run rules like the following error.
```sh
Failed to load textlint's rule module: "textlint-rule-max-number-of-lines" is not found.
```
I supposed that was a mistaken in `README.md`, so I changed it to what I think more correctly.

If you accepted this PR, I'm really happy to contribute to your tools.